### PR TITLE
add option of using the Blablador API

### DIFF
--- a/R/klaus.R
+++ b/R/klaus.R
@@ -116,8 +116,118 @@ chatai_models <- function() {
   return(response_parsed$data)
 }
 
+# 3) Interaction with the Blablador API
 
-# 3) Helper function to convert a data frame to JSON to explain the coding schema to the LLM
+blablador <- function(x = "",
+                      system_prompt = "You are a helpful assistant",
+                      model = "1 - Llama3 405 the best general model and big context size",
+                      temperature = 0) {
+  stopifnot(
+    is.character(x), length(x) == 1,
+    is.character(system_prompt), length(system_prompt) == 1,
+    is.character(model), length(model) == 1, nzchar(model),
+    is.numeric(temperature), length(temperature) == 1, temperature >= 0
+  )
+  api_key <- Sys.getenv("BLABLADOR_API_KEY")
+  if (api_key == "") {
+    stop("API key not found. Please set the 'BLABLADOR_API_KEY' environment variable.", call. = FALSE)
+  }
+  url <- "https://api.helmholtz-blablador.fz-juelich.de/v1/chat/completions"
+  headers <- c(
+    "Accept" = "application/json",
+    "Authorization" = paste0("Bearer ", api_key),
+    "Content-Type" = "application/json"
+  )
+  body <- list(
+    model = model,
+    messages = list(
+      list(role = "system", content = system_prompt),
+      list(role = "user", content = x)
+    ),
+    temperature = temperature
+  )
+  response <- tryCatch(
+    httr::POST(url,
+               httr::add_headers(.headers = headers),
+               body = jsonlite::toJSON(body, auto_unbox = TRUE),
+               encode = "json"),
+    error = function(e) {
+      stop("HTTP request failed: ", e$message, call. = FALSE)
+    }
+  )
+  status_code <- httr::status_code(response)
+  if (status_code >= 400) {
+    error_content <- httr::content(response, as = "text", encoding = "UTF-8")
+    stop(sprintf("API request failed with status %d. Response: %s",
+                 status_code, error_content), call. = FALSE)
+  }
+  if (status_code >= 300) {
+    warning(sprintf("API request returned status %d.", status_code))
+  }
+  if (status_code != 200) {
+    warning(sprintf("API request returned unexpected status %d.", status_code))
+  }
+  response_text <- httr::content(response, as = "text", encoding = "UTF-8")
+  response_parsed <- tryCatch(
+    jsonlite::fromJSON(response_text),
+    error = function(e) {
+      stop("Failed to parse JSON response: ", e$message,
+           "\nRaw response: ", response_text, call. = FALSE)
+    }
+  )
+  content_out <- tryCatch(
+    response_parsed$choices$message$content[[1]], # Assuming single choice often
+    error = function(e) NULL # Return NULL if path doesn't exist
+  )
+  if (is.null(content_out) || !is.character(content_out)) {
+    stop("Unexpected API response structure. Could not extract content.",
+         "\nParsed response: ", utils::str(response_parsed), call. = FALSE)
+  }
+  return(content_out)
+}
+
+# 4) List the available Blablador API models
+
+blablador_models <- function() {
+  api_key <- Sys.getenv("BLABLADOR_API_KEY")
+  if (api_key == "") {
+    stop("API key not found. Please set the 'BLABLADOR_API_KEY' environment variable.", call. = FALSE)
+  }
+  url <- "https://api.helmholtz-blablador.fz-juelich.de/v1/models"
+  headers <- c(
+    "Accept" = "application/json",
+    "Authorization" = paste0("Bearer ", api_key)
+  )
+  response <- tryCatch(
+    httr::GET(url,
+              httr::add_headers(.headers = headers)
+    ),
+    error = function(e) {
+      stop("HTTP request failed: ", e$message, call. = FALSE)
+    }
+  )
+  status_code <- httr::status_code(response)
+  if (status_code != 200) {
+    error_content <- httr::content(response, as = "text", encoding = "UTF-8")
+    stop(sprintf("API request failed with status %d. Response: %s",
+                 status_code, error_content), call. = FALSE)
+  }
+  response_text <- httr::content(response, as = "text", encoding = "UTF-8")
+  response_parsed <- tryCatch(
+    jsonlite::fromJSON(response_text),
+    error = function(e) {
+      stop("Failed to parse JSON response: ", e$message,
+           "\nRaw response: ", response_text, call. = FALSE)
+    }
+  )
+  if (!is.list(response_parsed) || !("data" %in% names(response_parsed))) {
+    stop("Unexpected API response structure. Missing 'data' element.",
+         "\nParsed response structure: ", utils::str(response_parsed), call. = FALSE)
+  }
+  return(response_parsed$data)
+}
+
+# 5) Helper function to convert a data frame to JSON to explain the coding schema to the LLM
 
 parse_codebook <- function(x) {
   required_cols <- c("category", "label", "instructions")
@@ -148,7 +258,7 @@ parse_codebook <- function(x) {
 }
 
 
-# 4) Internal helper function to call different LLM APIs
+# 6) Internal helper function to call different LLM APIs
 
 .call_llm <- function(provider, model, user_prompt, system_prompt, temperature) {
   providers_tidyllm <- c("claude", "gemini", "openai", "ollama")
@@ -168,7 +278,25 @@ parse_codebook <- function(x) {
     )
     message(glue::glue("Coding data with {provider} / {model}..."))
     return(response)
-  } else if (provider %in% providers_tidyllm) {
+  } 
+  if (provider == "blablador") {
+    if (is.null(model)) model <- "1 - Llama3 405 the best general model and big context size"
+    response <- tryCatch({
+      blablador(
+        x = user_prompt,
+        system_prompt = system_prompt,
+        model = model, 
+        temperature = temperature
+      )
+    },
+    error = function(e) {
+      stop(glue::glue("Blablador API call failed for model '{model}': {conditionMessage(e)}"), call. = FALSE)
+    }
+    )
+    message(glue::glue("Coding data with {provider} / {model}..."))
+    return(response)
+  }
+  else if (provider %in% providers_tidyllm) {
     if (provider == "claude") {
       if (is.null(model)) model <- "claude-3-7-sonnet-20250219"
       response <- tryCatch({
@@ -220,7 +348,7 @@ parse_codebook <- function(x) {
 }
 
 
-# 5) Main function for coding content
+# 7) Main function for coding content
 
 code_content <- function(x,
                          general_instructions,
@@ -235,7 +363,7 @@ code_content <- function(x,
                          keep_all_original_rows = TRUE) {
   
   # Check if provider is supported (can be expanded)
-  supported_providers <- c("chatai", "claude", "gemini", "openai", "ollama")
+  supported_providers <- c("chatai", "claude", "gemini", "openai", "ollama", "blablador")
   if (!(provider %in% supported_providers)) {
     stop(glue::glue("Unsupported API provider: '{provider}'. Supported: {paste(supported_providers, collapse=', ')}"), call. = FALSE)
   }

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![klaus](logo.png?raw=true "klaus")
 
-Modern large language models offer considerable advantages for standardized content analysis. `klaus` facilitates use of both proprietary and open source LLMs by offering a simple interface through which to serve data and apply categorization. Presently the package supports the proprietary APIs of OpenAI, Anthropic and Google, as well as for [ollama](https://ollama.com/) (through [tidyllm](https://cran.r-project.org/package=tidyllm)), in addition to the non-commercial [ChatAI API](https://docs.hpc.gwdg.de/services/saia/index.html) service provided by [GWDG](https://gwdg.de/en/). 
+Modern large language models (LLMs) offer considerable advantages for standardized content analysis. `klaus` facilitates use of both proprietary and open source LLMs by offering a simple interface through which to serve data and apply categorization. Presently the package supports the proprietary APIs of OpenAI, Anthropic and Google, as well as for local use via [ollama](https://ollama.com/) (through [tidyllm](https://cran.r-project.org/package=tidyllm)). In addition, for academic research, it is also possible to use the non-commercial [ChatAI API](https://docs.hpc.gwdg.de/services/saia/index.html) service provided by [GWDG](https://gwdg.de/en/) or [Blablador](https://helmholtz.cloud/services/?serviceID=d7d5c597-a2f6-4bd1-b71e-4d6499d98570&sortByAttribute=userCount) provided by the [Forschungszentrum Jülich](https://www.fz-juelich.de/en). 
 
 ## Installation
 
@@ -12,16 +12,16 @@ Modern large language models offer considerable advantages for standardized cont
     
     library(klaus)
   
-The package requires API access keys to be stored as environment variables. These can be set via the [usethis](https://cran.r-project.org/package=usethis) package.
+The package requires API keys to be stored as environment variables. These can be set via the [usethis](https://cran.r-project.org/package=usethis) package.
 
     usethis::edit_r_environ()
     
-The keys should be called `OPENAI_API_KEY`, `GOOGLE_API_KEY`, `ANTHROPIC_API_KEY` and `CHATAI_API_KEY`. Simply add an 
-entry in the form `OPENAI_API_KEY="xxxxxxxxxxxx"` to your .Renviron file. 
+The keys should be called `OPENAI_API_KEY`, `GOOGLE_API_KEY`, `ANTHROPIC_API_KEY`, `CHATAI_API_KEY`, and `BLABLADOR_API_KEY`. Simply add an 
+entry in the form `OPENAI_API_KEY="xxxxxxxxxxxx"` to your `.Renviron` file. 
 
 ## Usage
 
-The package's main function `code_content()` takes general instructions, formatting instructions and a codebook as its arguments.
+The main function of the package is `code_content()` which takes general instructions, formatting instructions, and a codebook as its arguments.
 
 First, prepare the general and formatting instructions.
       
@@ -50,7 +50,7 @@ Prepare the codebook. The codebook should be a data frame or tibble with the col
                        "Code this if the sentiment of the tweet is negative", 
                        "Code this if the sentiment of the tweet is neutral"))
   
-Code the data (here with gpt-4o)
+Code the data (in this example with gpt-4o)
 
     result <- code_content(data_to_code, general_instructions, formatting_instructions, codebook)
     
@@ -85,9 +85,22 @@ ChatAI can be specified as the API to use with the *provider* parameter. In the 
 
 For convenience, the `chatai_models()` function lists all models available via the ChatAI API.
 
+## Coding with the Blablador API
+
+To use the Blablador API, you need to [request an API key](https://sdlaml.pages.jsc.fz-juelich.de/ai/guides/blablador_api_access/). Blablador can be specified as the API to use with the *provider* parameter. In the example below, we specify use of Blablador as provider and Llama3 405 as the model.
+
+    coded_data_chatai <- code_content(data_to_code, 
+                                      general_instructions, 
+                                      formatting_instructions, 
+                                      codebook, 
+                                      provider = "blablador", 
+                                      model = "1 - Llama3 405 the best general model and big context size")
+
+For convenience, the `blablador_models()` function lists all models available via the Blablador API.
+
 ## Coding with ollama
 
-Coding with ollama requires having [ollama](https://ollama.com/) and the model you would like to use installed, with no other requirements. 
+Coding with ollama requires having [ollama](https://ollama.com/) and the model you would like to use installed. 
 
     coded_data_ollama <- code_content(data_to_code, 
                                       general_instructions, 


### PR DESCRIPTION
I have added the option of using [Blablador](https://helmholtz.cloud/services/?serviceID=d7d5c597-a2f6-4bd1-b71e-4d6499d98570&sortByAttribute=userCount) and its [API](https://sdlaml.pages.jsc.fz-juelich.de/ai/guides/blablador_api_access/) provided by the [Forschungszentrum Jülich](https://www.fz-juelich.de/en) as a potential alternative to the ChatAI API.